### PR TITLE
Update fabric.rb to support latest version

### DIFF
--- a/Casks/fabric.rb
+++ b/Casks/fabric.rb
@@ -1,13 +1,13 @@
 cask 'fabric' do
-  version '2.2.2'
-  sha256 'd69784cfc2c7d4d5479924b216a8c02c2c087466603ef36478c24c974ab0d930'
+  version :latest
+  sha256 :no_check
 
+  # amazonaws.com is the official download host per the vendor homepage
   url 'https://ssl-download-crashlytics-com.s3.amazonaws.com/fabric/builds/Fabric-latest.zip'
-  appcast 'https://ssl-download-crashlytics-com.s3.amazonaws.com/fabric/version.xml',
-          checkpoint: 'c9964f4d5330fb84c3f1ed5adb2f1a2b32369b058d73207193d465792bf33c22'
+  appcast 'https://ssl-download-crashlytics-com.s3.amazonaws.com/fabric/version.xml'
   name 'Fabric'
   homepage 'https://get.fabric.io/'
-  license :unknown # TODO: change license and remove this comment; ':unknown' is a machine-generated placeholder
+  license :gratis
 
   app 'Fabric.app'
 end


### PR DESCRIPTION
Switching to preferred mechanism when a versioned download URL is not available (here upgrade from 2.2.2 to 2.3.0, both referring -latest.zip).