### PR TITLE
Ishiiruka Dolphin 5.0 Stable build 744

### DIFF
--- a/Casks/ishiiruka-dolphin.rb
+++ b/Casks/ishiiruka-dolphin.rb
@@ -1,0 +1,10 @@
+cask 'ishiiruka-dolphin' do
+  version '5.0b744'
+  sha256 'ede546c02c8a927f87be1f5986498960a35207e1e0f13f6e5c343264e6da3406'
+
+  url 'https://github.com/ntapiam/Ishiiruka/releases/download/v5.0b744/Ishiiruka.5.0.Stable.dmg'
+  name 'Ishiiruka Dolphin'
+  homepage 'https://github.com/Tinob/Ishiiruka'
+
+  app 'Ishiiruka Dolphin 5.0 Stable.app'
+end


### PR DESCRIPTION
This is a fork of the official Dolphin Wii and Gamecube emulator
providing reduced graphics cpu usage and better compatibility with old
devices.
I've built the .app bundle from my own fork which is up-to-date with
Tinob/master which is the official repo. They don't provide any Mac
builds so I thought why not provide my own.