### PR TITLE
Add TupiTube.app 0.2.11

### DIFF
--- a/Casks/tupitube.rb
+++ b/Casks/tupitube.rb
@@ -1,0 +1,12 @@
+cask 'tupitube' do
+  version '0.2.11'
+  sha256 'c31f859081746c75e867b16bbedb6118e8c774a6c931852855094c40126598a1'
+
+  url "https://downloads.sourceforge.net/tupi2d/tupitube_desk_#{version}.dmg"
+  appcast 'https://sourceforge.net/projects/tupi2d/rss?path=/Mac%20OSX'
+  name 'TupiTube Desk'
+  name 'Tupi2d'
+  homepage 'https://www.maefloresta.com/'
+
+  app 'TupiTube.app'
+end


### PR DESCRIPTION
Could not be added to the homebrew-cask due to login wall.