### PR TITLE
Add Boxy Suite Latest

### DIFF
--- a/Casks/boxy-suite.rb
+++ b/Casks/boxy-suite.rb
@@ -1,0 +1,13 @@
+cask 'boxy-suite' do
+  version :latest
+  sha256 :no_check
+
+  # boxyteam-static.s3.amazonaws.com was verified as official when first introduced to the cask
+  url 'https://boxyteam-static.s3.amazonaws.com/release/Boxy%20Suite.dmg'
+  name 'Boxy Suite'
+  homepage 'https://www.boxysuite.com/'
+
+  app 'Boxy Dashboard.app'
+  app 'Boxy for Gmail.app'
+  app 'Boxy for Calendar.app'
+end


### PR DESCRIPTION
Adds the three Boxy suite applications:
- Boxy for Gmail.app
- Boxy for Calendar.app
- Boxy Dashboard.app

These are curated and tweaked single-site browsers for some of the Google productivity suite.

This is a walled build.